### PR TITLE
Add TeachCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TeachCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TeachCommand.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.tag.Mod;
+
+public class TeachCommand extends Command {
+    public static final String COMMAND_WORD = "teach";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets up default module users are teaching.\n"
+            + "Parameters: "
+            + PREFIX_MOD + "MODULE \n"
+            + "Example: " + COMMAND_WORD
+            + " " + PREFIX_MOD + "CS1231S ";
+
+    public static final String MESSAGE_SUCCESS = "Default module successfully added.";
+
+    private final Mod module;
+
+    public TeachCommand(Mod module) {
+        requireNonNull(module);
+        this.module = module;
+    }
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.setTeaching(module);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.TeachCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TeachCommand.COMMAND_WORD:
+            return new TeachCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/TeachCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TeachCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD;
+import static seedu.address.logic.parser.ParserUtil.parseMod;
+
+import seedu.address.logic.commands.TeachCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Mod;
+
+public class TeachCommandParser implements Parser<TeachCommand> {
+    public TeachCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_MOD);
+
+        try {
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_MOD);
+
+            Mod module = null;
+
+            if (argMultimap.getValue(PREFIX_MOD).isPresent()) {
+                module = parseMod(argMultimap.getValue(PREFIX_MOD).get());
+            }
+
+            return new TeachCommand(module);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TeachCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Mod;
 
 /**
  * The API of the Model component.
@@ -43,6 +44,17 @@ public interface Model {
      * Sets the user prefs' address book file path.
      */
     void setAddressBookFilePath(Path addressBookFilePath);
+
+    /**
+     * Returns the module the user is teaching.
+     *
+     */
+    Mod getTeaching();
+
+    /**
+     * Sets the module the user is teaching.
+     */
+    void setTeaching(Mod module);
 
     /**
      * Replaces address book data with the data in {@code addressBook}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Mod;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -62,6 +63,16 @@ public class ModelManager implements Model {
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         userPrefs.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public Mod getTeaching() {
+        return userPrefs.getTeaching();
+    }
+    @Override
+    public void setTeaching(Mod module) {
+        requireNonNull(module);
+        userPrefs.setTeaching(module);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.tag.Mod;
 
 /**
  * Represents User's preferences.
@@ -16,6 +17,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
 
+    private Mod teaching;
     /**
      * Creates a {@code UserPrefs} with default values.
      */
@@ -54,6 +56,14 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void setAddressBookFilePath(Path addressBookFilePath) {
         requireNonNull(addressBookFilePath);
         this.addressBookFilePath = addressBookFilePath;
+    }
+
+    public Mod getTeaching() {
+        return this.teaching;
+    }
+    public void setTeaching(Mod module) {
+        requireNonNull(module);
+        this.teaching = module;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Mod;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -105,6 +106,16 @@ public class AddCommandTest {
 
         @Override
         public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Mod getTeaching() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTeaching(Mod module) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Currently, the product displays all the
in a single page.

To facilitate easy of navigation for
users, default course is set up using
TeachCommand command.

This is so that the next time users log into
the product, they can directly see the list
of TAs teaching under them.