### PR TITLE
Modify FreeTime to handle days of the week

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -25,8 +25,8 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -79,6 +79,26 @@ public class EditCommand extends Command {
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
 
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToEdit}
+     * edited with {@code editPersonDescriptor}.
+     */
+    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+        assert personToEdit != null;
+
+        Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
+        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
+        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
+        Telegram updatedTelegram = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
+        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        FreeTime updatedFreeTime = editPersonDescriptor.getFreeTime().orElse(personToEdit.getFreeTime());
+        Set<Mod> updatedMods = editPersonDescriptor.getMods().orElse(personToEdit.getMods());
+        Hour updatedHour = editPersonDescriptor.getHour().orElse(personToEdit.getHour());
+
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedTelegram, updatedTags, updatedFreeTime,
+                updatedMods, updatedHour);
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -98,26 +118,6 @@ public class EditCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
-    }
-
-    /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
-     */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
-        assert personToEdit != null;
-
-        Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
-        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
-        Telegram updatedTelegram = editPersonDescriptor.getTelegram().orElse(personToEdit.getTelegram());
-        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-        FreeTime updatedFreeTime = editPersonDescriptor.getFreeTime().orElse(personToEdit.getFreeTime());
-        Set<Mod> updatedMods = editPersonDescriptor.getMods().orElse(personToEdit.getMods());
-        Hour updatedHour = editPersonDescriptor.getHour().orElse(personToEdit.getHour());
-
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedTelegram, updatedTags, updatedFreeTime,
-                updatedMods, updatedHour);
     }
 
     @Override
@@ -184,44 +184,36 @@ public class EditCommand extends Command {
             return CollectionUtil.isAnyNonNull(name, phone, email, telegram, tags, mods, freeTime, hour);
         }
 
-        public void setName(Name name) {
-            this.name = name;
-        }
-
         public Optional<Name> getName() {
             return Optional.ofNullable(name);
         }
 
-        public void setPhone(Phone phone) {
-            this.phone = phone;
+        public void setName(Name name) {
+            this.name = name;
         }
 
         public Optional<Phone> getPhone() {
             return Optional.ofNullable(phone);
         }
 
-        public void setEmail(Email email) {
-            this.email = email;
+        public void setPhone(Phone phone) {
+            this.phone = phone;
         }
 
         public Optional<Email> getEmail() {
             return Optional.ofNullable(email);
         }
 
-        public void setTelegram(Telegram telegram) {
-            this.telegram = telegram;
+        public void setEmail(Email email) {
+            this.email = email;
         }
 
         public Optional<Telegram> getTelegram() {
             return Optional.ofNullable(telegram);
         }
 
-        /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public void setTags(Set<Tag> tags) {
-            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        public void setTelegram(Telegram telegram) {
+            this.telegram = telegram;
         }
 
         /**
@@ -234,22 +226,22 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
-        public void setFreeTime(FreeTime freeTime) {
-            if (freeTime != FreeTime.EMPTY_FREE_TIME) {
-                this.freeTime = freeTime;
-            }
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
         }
 
         public Optional<FreeTime> getFreeTime() {
             return Optional.ofNullable(freeTime);
         }
 
-        /**
-         * Sets {@code mods} to this object's {@code mods}.
-         * A defensive copy of {@code mods} is used internally.
-         */
-        public void setMods(Set<Mod> mods) {
-            this.mods = (mods != null) ? new HashSet<>(mods) : null;
+        public void setFreeTime(FreeTime freeTime) {
+            if (freeTime != FreeTime.EMPTY_FREE_TIME) {
+                this.freeTime = freeTime;
+            }
         }
 
         /**
@@ -262,12 +254,20 @@ public class EditCommand extends Command {
             return (mods != null) ? Optional.of(Collections.unmodifiableSet(mods)) : Optional.empty();
         }
 
-        public void setHour(Hour hour) {
-            this.hour = hour;
+        /**
+         * Sets {@code mods} to this object's {@code mods}.
+         * A defensive copy of {@code mods} is used internally.
+         */
+        public void setMods(Set<Mod> mods) {
+            this.mods = (mods != null) ? new HashSet<>(mods) : null;
         }
 
         public Optional<Hour> getHour() {
             return Optional.ofNullable(hour);
+        }
+
+        public void setHour(Hour hour) {
+            this.hour = hour;
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -16,8 +16,8 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -30,6 +30,15 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new AddCommand object
  */
 public class AddCommandParser implements Parser<AddCommand> {
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
@@ -62,14 +71,5 @@ public class AddCommandParser implements Parser<AddCommand> {
         Person person = new Person(name, phone, email, telegram, tagList, freeTime, modList, hour);
 
         return new AddCommand(person);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values
-     * in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,6 +16,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_FROM = new Prefix("from/");
 
     public static final Prefix PREFIX_TO = new Prefix("to/");
+    public static final Prefix PREFIX_FREE_TIME = new Prefix("ft/");
     public static final Prefix PREFIX_HOUR = new Prefix("h/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -11,8 +12,9 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.availability.FreeTime;
+import seedu.address.model.availability.TimeInterval;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
@@ -129,23 +131,55 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code String from} and {@code String to} into a {@code FreeTime}.
+     * Parses a collection of {@code intervals} into a {@code FreeTime}.
      */
-    public static FreeTime parseFreeTime(String from, String to) throws DateTimeParseException, ParseException {
-        if (from == null || to == null) {
-            return FreeTime.EMPTY_FREE_TIME;
-        }
+    public static FreeTime parseFreeTime(Collection<String> intervals) throws DateTimeParseException, ParseException {
         try {
-            LocalTime start = LocalTime.parse(from);
-            LocalTime end = LocalTime.parse(to);
-            if (!FreeTime.isValidFreeTime(start, end)) {
+            requireNonNull(intervals);
+            final ArrayList<TimeInterval> timeIntervals = new ArrayList<>();
+            for (String interval : intervals) {
+                String[] splitInterval = interval.split("-");
+                LocalTime from = LocalTime.parse(splitInterval[0]);
+                LocalTime to = LocalTime.parse(splitInterval[1]);
+                if (!TimeInterval.isValidTimeInterval(from, to)) {
+                    throw new ParseException(TimeInterval.MESSAGE_CONSTRAINTS);
+                }
+                timeIntervals.add(new TimeInterval(from, to));
+            }
+            if (!FreeTime.isValidFreeTime(timeIntervals)) {
                 throw new ParseException(FreeTime.MESSAGE_CONSTRAINTS);
             }
-            return new FreeTime(start, end);
+            return new FreeTime(timeIntervals);
         } catch (DateTimeParseException e) {
             throw new ParseException(FreeTime.MESSAGE_CONSTRAINTS);
         }
+    }
 
+    /**
+     * Parses a collection of {@code String from} and {@code String to} into a {@code FreeTime}.
+     * This assumes that the TA has the same availability throughout the week.
+     */
+    public static FreeTime parseFreeTime(String from, String to) throws DateTimeParseException, ParseException {
+        try {
+            if (from == null || to == null) {
+                return FreeTime.EMPTY_FREE_TIME;
+            }
+            final ArrayList<TimeInterval> timeIntervals = new ArrayList<>();
+            for (int i = 0; i < FreeTime.NUM_DAYS; i++) {
+                LocalTime fromDate = LocalTime.parse(from);
+                LocalTime toDate = LocalTime.parse(to);
+                if (!TimeInterval.isValidTimeInterval(fromDate, toDate)) {
+                    throw new ParseException(TimeInterval.MESSAGE_CONSTRAINTS);
+                }
+                timeIntervals.add(new TimeInterval(fromDate, toDate));
+            }
+            if (!FreeTime.isValidFreeTime(timeIntervals)) {
+                throw new ParseException(FreeTime.MESSAGE_CONSTRAINTS);
+            }
+            return new FreeTime(timeIntervals);
+        } catch (DateTimeParseException e) {
+            throw new ParseException(FreeTime.MESSAGE_CONSTRAINTS);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/availability/FreeTime.java
+++ b/src/main/java/seedu/address/model/availability/FreeTime.java
@@ -2,9 +2,11 @@ package seedu.address.model.availability;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 
 /**
@@ -84,7 +86,8 @@ public class FreeTime {
         StringBuilder str = new StringBuilder("\n");
 
         for (int i = 0; i < NUM_DAYS; i++) {
-            str.append(String.format("%s: %s\n", DayOfWeek.of(i + 1), this.intervals.get(i)));
+            String day = DayOfWeek.of(i + 1).getDisplayName(TextStyle.SHORT, Locale.ENGLISH);
+            str.append(String.format("%s: %s\n", day, this.intervals.get(i)));
         }
         return str.toString();
     }

--- a/src/main/java/seedu/address/model/availability/FreeTime.java
+++ b/src/main/java/seedu/address/model/availability/FreeTime.java
@@ -1,0 +1,125 @@
+package seedu.address.model.availability;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Represents a Person's free time of the day in the TAM.
+ */
+public class FreeTime {
+    public static final FreeTime EMPTY_FREE_TIME = new FreeTime();
+    public static final String MESSAGE_CONSTRAINTS =
+            "TA's free time should have a start and end time in HH:mm format";
+    public static final int NUM_DAYS = 5;
+    public final ArrayList<TimeInterval> intervals = new ArrayList<>(Collections.nCopies(NUM_DAYS, null));
+
+    /**
+     * Constructs a {@code FreeTime}.
+     * Will assume that the availability is the same of all days of the week.
+     *
+     * @param from Start time.
+     * @param to   End time.
+     */
+    public FreeTime(LocalTime from, LocalTime to) {
+        for (int i = 0; i < NUM_DAYS; i++) {
+            this.intervals.set(i, new TimeInterval(from, to));
+        }
+    }
+
+    /**
+     * Empty FreeTime
+     */
+    private FreeTime() {
+    }
+
+
+    /**
+     * Initializes {@code FreeTime} with availability.
+     *
+     * @param intervals {@code List} of {@code TimeIntervals} which represent availability.
+     */
+    public FreeTime(List<TimeInterval> intervals) {
+        for (int i = 0; i < NUM_DAYS; i++) {
+            this.intervals.set(i, intervals.get(i));
+        }
+    }
+
+
+    /**
+     * Returns true if given start and end time is valid.
+     */
+    public static boolean isValidFreeTime(List<TimeInterval> intervals) {
+        return intervals.size() == NUM_DAYS;
+    }
+
+    /**
+     * Returns availability on all days of the week.
+     *
+     * @return an array of {@code TimeInterval}.
+     */
+    public ArrayList<TimeInterval> getIntervals() {
+        assert this.intervals.size() == NUM_DAYS;
+        return this.intervals;
+    }
+
+    /**
+     * Returns availability of a specific day of the week.
+     *
+     * @param day day of the week, Monday - 1.
+     * @return Availability represented by {@code TimeInterval}.
+     */
+    public TimeInterval getDay(int day) {
+        return this.intervals.get(day);
+    }
+
+    @Override
+    public String toString() {
+        if (this.equals(FreeTime.EMPTY_FREE_TIME)) {
+            return " ";
+        }
+        StringBuilder str = new StringBuilder("\n");
+
+        for (int i = 0; i < NUM_DAYS; i++) {
+            str.append(String.format("%s: %s\n", DayOfWeek.of(i + 1), this.intervals.get(i)));
+        }
+        return str.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (this == EMPTY_FREE_TIME) {
+            return false;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FreeTime)) {
+            return false;
+        }
+
+        FreeTime otherFreeTime = (FreeTime) other;
+
+        for (int i = 0; i < NUM_DAYS; i++) {
+            TimeInterval thisInterval = this.intervals.get(i);
+            TimeInterval otherInterval = otherFreeTime.intervals.get(i);
+            if (thisInterval == null && otherInterval == null) {
+                continue;
+            }
+            if (thisInterval == null || otherInterval == null) {
+                return false;
+            }
+            if (!thisInterval.equals(otherInterval)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/seedu/address/model/availability/TimeInterval.java
+++ b/src/main/java/seedu/address/model/availability/TimeInterval.java
@@ -1,46 +1,39 @@
-package seedu.address.model.person;
+package seedu.address.model.availability;
 
-
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Represents a Person's free time of the day in the TAM.
- * Guarantees: immutable; is valid as declared in {@link #isValidFreeTime(LocalTime, LocalTime)}
+ * Represents a period of time
+ * Guarantees: immutable; is valid as declared in {@link #isValidTimeInterval(LocalTime, LocalTime)}
  */
-public class FreeTime {
-    public static final FreeTime EMPTY_FREE_TIME = new FreeTime();
+public class TimeInterval {
     public static final String MESSAGE_CONSTRAINTS =
             "TA's free time should have a start and end time in HH:mm format";
     public final LocalTime from;
     public final LocalTime to;
 
     /**
-     * Constructs a {@code FreeTime}.
+     * Constructs a {@code TimeInterval}.
      *
      * @param from Start time.
      * @param to   End time.
      */
-    public FreeTime(LocalTime from, LocalTime to) {
-        checkArgument(isValidFreeTime(from, to), MESSAGE_CONSTRAINTS);
+    public TimeInterval(LocalTime from, LocalTime to) {
+        requireNonNull(from);
+        requireNonNull(to);
+        checkArgument(isValidTimeInterval(from, to), MESSAGE_CONSTRAINTS);
         this.from = from;
         this.to = to;
     }
 
     /**
-     * Empty FreeTime
-     */
-    private FreeTime() {
-        this.from = null;
-        this.to = null;
-    }
-
-    /**
      * Returns true if given start and end time is valid.
      */
-    public static boolean isValidFreeTime(LocalTime from, LocalTime to) {
+    public static boolean isValidTimeInterval(LocalTime from, LocalTime to) {
         return to.isAfter(from);
     }
 
@@ -50,9 +43,6 @@ public class FreeTime {
      * @return From time in HH:mm format.
      */
     public String getFrom() {
-        if (from == null) {
-            return null;
-        }
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm");
         return from.format(dtf);
     }
@@ -63,18 +53,12 @@ public class FreeTime {
      * @return To time in HH:mm format.
      */
     public String getTo() {
-        if (to == null) {
-            return null;
-        }
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm");
         return to.format(dtf);
     }
 
     @Override
     public String toString() {
-        if (this.equals(FreeTime.EMPTY_FREE_TIME)) {
-            return " ";
-        }
         return String.format("%s-%s", from, to);
     }
 
@@ -83,18 +67,14 @@ public class FreeTime {
         if (other == this) {
             return true;
         }
-        if (this == EMPTY_FREE_TIME) {
-            return false;
-        }
 
         // instanceof handles nulls
-        if (!(other instanceof seedu.address.model.person.FreeTime)) {
+        if (!(other instanceof TimeInterval)) {
             return false;
         }
 
-        seedu.address.model.person.FreeTime otherFreeTime = (seedu.address.model.person.FreeTime) other;
+        TimeInterval otherInterval = (TimeInterval) other;
 
-        return from.equals(otherFreeTime.from) && to.equals(otherFreeTime.to);
+        return from.equals(otherInterval.from) && to.equals(otherInterval.to);
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.tag.Mod;
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -7,8 +7,8 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -16,6 +16,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
 import seedu.address.model.tag.Mod;
 import seedu.address.model.tag.Tag;
+
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
  * @formatter:off

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -1,6 +1,5 @@
 package seedu.address.storage;
 
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -11,8 +10,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.availability.FreeTime;
+import seedu.address.model.availability.TimeInterval;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -33,8 +33,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String telegram;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
-    private final String from;
-    private final String to;
+    private final List<JsonAdaptedTimeInterval> intervals = new ArrayList<>();
 
     private final List<JsonAdaptedMod> mods = new ArrayList<>();
     private final String hour;
@@ -44,11 +43,11 @@ class JsonAdaptedPerson {
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("telegram") String telegram,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("from") String from,
-            @JsonProperty("to") String to,
-            @JsonProperty("mods") List<JsonAdaptedMod> mods,
-            @JsonProperty("hour") String hour) {
+                             @JsonProperty("email") String email, @JsonProperty("telegram") String telegram,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags,
+                             @JsonProperty("freeTime") List<JsonAdaptedTimeInterval> intervals,
+                             @JsonProperty("mods") List<JsonAdaptedMod> mods,
+                             @JsonProperty("hour") String hour) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -56,8 +55,14 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
-        this.from = from;
-        this.to = to;
+
+        if (intervals != null) {
+            this.intervals.addAll(intervals);
+        } else {
+            for (int i = 0; i < FreeTime.NUM_DAYS; i++) {
+                this.intervals.add(null);
+            }
+        }
         if (mods != null) {
             this.mods.addAll(mods);
         }
@@ -75,8 +80,13 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
-        from = source.getFreeTime().getFrom();
-        to = source.getFreeTime().getTo();
+        source.getFreeTime().getIntervals().forEach(interval -> {
+            if (interval != null) {
+                intervals.add(new JsonAdaptedTimeInterval(interval));
+            } else {
+                intervals.add(null);
+            }
+        });
         mods.addAll(source.getMods().stream()
                 .map(JsonAdaptedMod::new)
                 .collect(Collectors.toList()));
@@ -99,6 +109,17 @@ class JsonAdaptedPerson {
         final List<Mod> personMods = new ArrayList<>();
         for (JsonAdaptedMod mod : mods) {
             personMods.add(mod.toModelType());
+        }
+
+        int countNulls = 0;
+        final List<TimeInterval> personTimeIntervals = new ArrayList<>();
+        for (JsonAdaptedTimeInterval timeInterval : intervals) {
+            if (timeInterval != null) {
+                personTimeIntervals.add(timeInterval.toModelType());
+            } else {
+                personTimeIntervals.add(null);
+                countNulls += 1;
+            }
         }
 
         if (name == null) {
@@ -136,16 +157,11 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        FreeTime modelFreeTime = FreeTime.EMPTY_FREE_TIME;
-        if (from != null && to != null) {
-            LocalTime start = LocalTime.parse(from);
-            LocalTime end = LocalTime.parse(to);
-            if (!FreeTime.isValidFreeTime(start, end)) {
-                throw new IllegalValueException(FreeTime.MESSAGE_CONSTRAINTS);
-            } else {
-                modelFreeTime = new FreeTime(start, end);
-            }
+        if (!FreeTime.isValidFreeTime(personTimeIntervals)) {
+            throw new IllegalValueException(FreeTime.MESSAGE_CONSTRAINTS);
         }
+        final FreeTime modelFreeTime = countNulls == FreeTime.NUM_DAYS
+                ? FreeTime.EMPTY_FREE_TIME : new FreeTime(personTimeIntervals);
 
         final Set<Mod> modelMods = new HashSet<>(personMods);
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedTimeInterval.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTimeInterval.java
@@ -1,0 +1,53 @@
+package seedu.address.storage;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.availability.FreeTime;
+import seedu.address.model.availability.TimeInterval;
+
+/**
+ * TAManager-friendly version of {@link FreeTime}.
+ */
+public class JsonAdaptedTimeInterval {
+    private final String interval;
+
+    /**
+     * Constructs a {@code JsonAdaptedTimeInterval} with the given {@code interval}.
+     */
+    @JsonCreator
+    public JsonAdaptedTimeInterval(String interval) {
+        this.interval = interval;
+    }
+
+    /**
+     * Converts a given {@code TimeInterval} into this class for TAManager use.
+     */
+    public JsonAdaptedTimeInterval(TimeInterval source) {
+        interval = source.toString();
+    }
+
+    @JsonValue
+    public String getInterval() {
+        return interval;
+    }
+
+    /**
+     * Converts this TAManager-friendly adapted mod object into the model's {@code TimeInterval} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted mod.
+     */
+    public TimeInterval toModelType() throws IllegalValueException, DateTimeParseException {
+        String[] splitInterval = interval.split("-");
+        LocalTime from = LocalTime.parse(splitInterval[0]);
+        LocalTime to = LocalTime.parse(splitInterval[1]);
+        if (!TimeInterval.isValidTimeInterval(from, to)) {
+            throw new IllegalValueException(TimeInterval.MESSAGE_CONSTRAINTS);
+        }
+        return new TimeInterval(from, to);
+    }
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -1,68 +1,125 @@
 {
   "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
-  "persons" : [ {
-    "name" : "Alice Pauline",
-    "phone" : "94351253",
-    "email" : "alice@example.com",
-    "telegram": "@aliceheyhey",
-    "tags" : [ ],
-    "mods" : [ ],
-    "hour" : "8"
-  }, {
-    "name" : "Benson Meier",
-    "phone" : "98765432",
-    "email" : "johnd@example.com",
-    "telegram": "@bensonnn123",
-    "tags" : [ "owesMoney", "friends" ],
-    "from": "21:15",
-    "to": "22:30",
-    "mods" : [ "CS1231", "CS2103T" ],
-    "hour" : "14"
-  }, {
-    "name" : "Carl Kurz",
-    "phone" : "95352563",
-    "email" : "heinz@example.com",
-    "telegram": "@carlkurz",
-    "tags" : [ ],
-    "mods" : [ ],
-    "hour" : "24"
-  }, {
-    "name" : "Daniel Meier",
-    "phone" : "87652533",
-    "email" : "cornelia@example.com",
-    "telegram": "@danielmeier",
-    "tags" : [ "friends" ],
-    "from": "10:45",
-    "to": "11:30",
-    "mods" : [ ],
-    "hour" : "38"
-  }, {
-    "name" : "Elle Meyer",
-    "phone" : "9482224",
-    "email" : "werner@example.com",
-    "telegram": "@hiitselle",
-    "tags" : [ ],
-    "mods" : [ ],
-    "hour" : "63"
-  }, {
-    "name" : "Fiona Kunz",
-    "phone" : "9482427",
-    "email" : "lydia@example.com",
-    "telegram": "@imfionaa",
-    "tags" : [ ],
-    "from": "21:10",
-    "to": "23:15",
-    "mods" : [ ],
-    "hour" : "39"
-  }, {
-    "name" : "George Best",
-    "phone" : "9482442",
-    "email" : "anna@example.com",
-    "telegram": "@georgiey",
-    "tags" : [ ],
-    "from": "07:00",
-    "to": "09:00",
-    "mods" : [ ],
-    "hour" : "46"
-  } ]
+  "persons": [
+    {
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "telegram": "@aliceheyhey",
+      "tags": [],
+      "freeTime": [
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "mods": [],
+      "hour": "8"
+    },
+    {
+      "name": "Benson Meier",
+      "phone": "98765432",
+      "email": "johnd@example.com",
+      "telegram": "@bensonnn123",
+      "tags": [
+        "owesMoney",
+        "friends"
+      ],
+      "freeTime": [
+        "21:15-22:30",
+        "21:15-22:30",
+        "21:15-22:30",
+        "21:15-22:30",
+        "21:15-22:30"
+      ],
+      "mods": [
+        "CS1231",
+        "CS2103T"
+      ],
+      "hour": "14"
+    },
+    {
+      "name": "Carl Kurz",
+      "phone": "95352563",
+      "email": "heinz@example.com",
+      "telegram": "@carlkurz",
+      "tags": [],
+      "freeTime": [
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "mods": [],
+      "hour": "24"
+    },
+    {
+      "name": "Daniel Meier",
+      "phone": "87652533",
+      "email": "cornelia@example.com",
+      "telegram": "@danielmeier",
+      "tags": [
+        "friends"
+      ],
+      "freeTime": [
+        "10:45-11:30",
+        "10:45-11:30",
+        "10:45-11:30",
+        "10:45-11:30",
+        "10:45-11:30"
+      ],
+      "mods": [],
+      "hour": "38"
+    },
+    {
+      "name": "Elle Meyer",
+      "phone": "9482224",
+      "email": "werner@example.com",
+      "telegram": "@hiitselle",
+      "tags": [],
+      "freeTime": [
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "mods": [],
+      "hour": "63"
+    },
+    {
+      "name": "Fiona Kunz",
+      "phone": "9482427",
+      "email": "lydia@example.com",
+      "telegram": "@imfionaa",
+      "tags": [],
+      "freeTime": [
+        "21:10-23:15",
+        "21:10-23:15",
+        "21:10-23:15",
+        "21:10-23:15",
+        "21:10-23:15"
+      ],
+      "mods": [],
+      "hour": "39"
+    },
+    {
+      "name": "George Best",
+      "phone": "9482442",
+      "email": "anna@example.com",
+      "telegram": "@georgiey",
+      "tags": [],
+      "freeTime": [
+        "07:00-09:00",
+        "07:00-09:00",
+        "07:00-09:00",
+        "07:00-09:00",
+        "07:00-09:00"
+      ],
+      "mods": [],
+      "hour": "46"
+    }
+  ]
 }

--- a/src/test/java/seedu/address/model/freetime/FreeTimeTest.java
+++ b/src/test/java/seedu/address/model/freetime/FreeTimeTest.java
@@ -1,12 +1,18 @@
-package seedu.address.model.person;
+package seedu.address.model.freetime;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.model.availability.FreeTime;
+import seedu.address.model.availability.TimeInterval;
 
 
 public class FreeTimeTest {
@@ -25,18 +31,20 @@ public class FreeTimeTest {
     @Test
     public void isValidFreeTime() {
         // null from and to
-        assertThrows(NullPointerException.class, () -> FreeTime.isValidFreeTime(null, null));
+        assertThrows(NullPointerException.class, () -> FreeTime.isValidFreeTime(null));
         LocalTime from = LocalTime.parse("12:20");
         LocalTime to = LocalTime.parse("23:44");
-        LocalTime closeFrom = LocalTime.parse("12:21");
-
-        // invalid free time
-        assertFalse(FreeTime.isValidFreeTime(from, from)); // same from and to
-        assertFalse(FreeTime.isValidFreeTime(to, from)); // to before from
+        ArrayList<TimeInterval> timeIntervals = new ArrayList<>();
+        for (int i = 0; i < FreeTime.NUM_DAYS; i++) {
+            timeIntervals.add(new TimeInterval(from, to));
+        }
 
         // valid free time
-        assertTrue(FreeTime.isValidFreeTime(from, to)); // to after from
-        assertTrue(FreeTime.isValidFreeTime(from, closeFrom)); // very short
+        assertTrue(FreeTime.isValidFreeTime(timeIntervals)); // same from and to
+        timeIntervals.add(new TimeInterval(from, to));
+
+        // more than 5 intervals, invalid
+        assertFalse(FreeTime.isValidFreeTime(timeIntervals)); // to after from
     }
 
     @Test
@@ -47,18 +55,15 @@ public class FreeTimeTest {
         FreeTime freeTime = new FreeTime(from, to);
 
         // same values -> returns true
-        assertTrue(freeTime.equals(new FreeTime(LocalTime.parse("12:20"), LocalTime.parse("23:44"))));
+        assertEquals(freeTime, new FreeTime(LocalTime.parse("12:20"), LocalTime.parse("23:44")));
 
         // same object -> returns true
-        assertTrue(freeTime.equals(freeTime));
+        assertEquals(freeTime, freeTime);
 
         // null -> returns false
-        assertFalse(freeTime.equals(null));
-
-        // different types -> returns false
-        assertFalse(freeTime.equals(5.0f));
+        assertNotEquals(null, freeTime);
 
         // different values -> returns false
-        assertFalse(freeTime.equals(new FreeTime(from, closeFrom)));
+        assertNotEquals(freeTime, new FreeTime(from, closeFrom));
     }
 }

--- a/src/test/java/seedu/address/model/freetime/TimeIntervalTest.java
+++ b/src/test/java/seedu/address/model/freetime/TimeIntervalTest.java
@@ -1,0 +1,63 @@
+package seedu.address.model.freetime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.availability.TimeInterval;
+
+public class TimeIntervalTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new TimeInterval(null, null));
+    }
+
+    @Test
+    public void constructor_invalidFreeTime_throwsIllegalArgumentException() {
+        LocalTime curr = LocalTime.now();
+        assertThrows(IllegalArgumentException.class, () -> new TimeInterval(curr, curr));
+    }
+
+    @Test
+    public void isValidFreeTime() {
+        // null from and to
+        assertThrows(NullPointerException.class, () -> TimeInterval.isValidTimeInterval(null, null));
+        LocalTime from = LocalTime.parse("12:20");
+        LocalTime to = LocalTime.parse("23:44");
+        LocalTime closeFrom = LocalTime.parse("12:21");
+
+        // invalid free time
+        assertFalse(TimeInterval.isValidTimeInterval(from, from)); // same from and to
+        assertFalse(TimeInterval.isValidTimeInterval(to, from)); // to before from
+
+        // valid free time
+        assertTrue(TimeInterval.isValidTimeInterval(from, to)); // to after from
+        assertTrue(TimeInterval.isValidTimeInterval(from, closeFrom)); // very short
+    }
+
+    @Test
+    public void equals() {
+        LocalTime from = LocalTime.parse("12:20");
+        LocalTime to = LocalTime.parse("23:44");
+        LocalTime closeFrom = LocalTime.parse("12:21");
+        TimeInterval freeTime = new TimeInterval(from, to);
+
+        // same values -> returns true
+        assertEquals(freeTime, new TimeInterval(LocalTime.parse("12:20"), LocalTime.parse("23:44")));
+
+        // same object -> returns true
+        assertEquals(freeTime, freeTime);
+
+        // null -> returns false
+        assertNotEquals(null, freeTime);
+
+        // different values -> returns false
+        assertNotEquals(freeTime, new TimeInterval(from, closeFrom));
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -6,6 +6,7 @@ import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORM
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,8 +14,9 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.availability.FreeTime;
+import seedu.address.model.availability.TimeInterval;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
@@ -27,8 +29,8 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_TELEGRAM = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
-    private static final String INVALID_FROM = "19:55";
-    private static final String INVALID_TO = "10:21";
+    private static final TimeInterval VALID_INTERVAL = new TimeInterval(LocalTime.parse("12:00"),
+            LocalTime.parse("20:00"));
 
     private static final String INVALID_MOD = "CS12231S";
 
@@ -40,8 +42,9 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final String VALID_FROM = "10:21";
-    private static final String VALID_TO = "19:55";
+    private static final List<JsonAdaptedTimeInterval> VALID_FREE_TIME = BENSON.getFreeTime().getIntervals()
+            .stream().map(JsonAdaptedTimeInterval::new)
+            .collect(Collectors.toList());
     private static final List<JsonAdaptedMod> VALID_MODS = BENSON.getMods().stream()
             .map(JsonAdaptedMod::new)
             .collect(Collectors.toList());
@@ -57,7 +60,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                        VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                        VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -65,7 +68,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +77,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                        VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                        VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,7 +85,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_TELEGRAM,
-                VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -91,7 +94,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_TELEGRAM,
-                        VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                        VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -99,7 +102,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_TELEGRAM,
-                VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +111,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTelegram_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_TELEGRAM,
-                        VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                        VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = Telegram.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -116,7 +119,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullTelegram_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                VALID_TAGS, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Telegram.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -127,7 +130,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                        invalidTags, VALID_FROM, VALID_TO, VALID_MODS, VALID_HOUR);
+                        invalidTags, VALID_FREE_TIME, VALID_MODS, VALID_HOUR);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -137,15 +140,17 @@ public class JsonAdaptedPersonTest {
         invalidMods.add(new JsonAdaptedMod(INVALID_MOD));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM, VALID_TAGS,
-                        VALID_FROM, VALID_TO, invalidMods, VALID_HOUR);
+                        VALID_FREE_TIME, invalidMods, VALID_HOUR);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidFreeTime_throwsIllegalValueException() {
+        List<JsonAdaptedTimeInterval> invalidFreeTime = new ArrayList<>(VALID_FREE_TIME);
+        invalidFreeTime.add(new JsonAdaptedTimeInterval(VALID_INTERVAL));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                        VALID_TAGS, INVALID_FROM, INVALID_TO, VALID_MODS, VALID_HOUR);
+                        VALID_TAGS, invalidFreeTime, VALID_MODS, VALID_HOUR);
         String expectedMessage = FreeTime.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -153,7 +158,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullFreeTime_doesNotThrowException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                VALID_TAGS, null, null, VALID_MODS, VALID_HOUR);
+                VALID_TAGS, null, VALID_MODS, VALID_HOUR);
         assertDoesNotThrow(person::toModelType);
     }
 
@@ -161,7 +166,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidHour_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                        VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, INVALID_HOUR);
+                        VALID_TAGS, VALID_FREE_TIME, VALID_MODS, INVALID_HOUR);
         String expectedMessage = Hour.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -169,7 +174,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullHour_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TELEGRAM,
-                VALID_TAGS, VALID_FROM, VALID_TO, VALID_MODS, null);
+                VALID_TAGS, VALID_FREE_TIME, VALID_MODS, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Hour.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -6,8 +6,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -117,6 +117,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setHour(new Hour(hour));
         return this;
     }
+
     public EditPersonDescriptor build() {
         return descriptor;
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -4,8 +4,8 @@ import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.FreeTime;
 import seedu.address.model.person.Hour;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -81,7 +81,7 @@ public class PersonBuilder {
     /**
      * Parses the {@code mods} into a {@code Set<Mod>} and set it to the {@code Person} that we are building.
      */
-    public PersonBuilder withMods(String ... mods) {
+    public PersonBuilder withMods(String... mods) {
         this.mods = SampleDataUtil.getModSet(mods);
         return this;
     }
@@ -129,6 +129,7 @@ public class PersonBuilder {
         this.hour = new Hour(hour);
         return this;
     }
+
     public Person build() {
         return new Person(name, phone, email, telegram, tags, freeTime, mods, hour);
     }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,20 +1,20 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREE_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
 
+import java.time.DayOfWeek;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.person.FreeTime;
+import seedu.address.model.availability.FreeTime;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Mod;
 import seedu.address.model.tag.Tag;
@@ -42,14 +42,18 @@ public class PersonUtil {
         sb.append(PREFIX_TELEGRAM + person.getTelegram().value + " ");
 
         if (!person.getFreeTime().equals(FreeTime.EMPTY_FREE_TIME)) {
-            sb.append(PREFIX_FROM + person.getFreeTime().getFrom() + " ");
-            sb.append(PREFIX_TO + person.getFreeTime().getTo() + " ");
+            FreeTime freeTime = person.getFreeTime();
+            sb.append(PREFIX_FREE_TIME);
+            for (int i = 0; i < FreeTime.NUM_DAYS; i++) {
+                sb.append(DayOfWeek.of(i) + ":" + freeTime.getDay(i).toString());
+            }
         }
+
         person.getTags().stream().forEach(
                 s -> sb.append(PREFIX_TAG + s.name + " ")
         );
         person.getMods().stream().forEach(
-            s -> sb.append(PREFIX_MOD + s.name + " ")
+                s -> sb.append(PREFIX_MOD + s.name + " ")
         );
         sb.append(PREFIX_HOUR + person.getHour().value + " ");
         return sb.toString();
@@ -64,8 +68,7 @@ public class PersonUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getTelegram().ifPresent(address -> sb.append(PREFIX_TELEGRAM).append(address.value).append(" "));
-        descriptor.getFreeTime().ifPresent(freeTime -> sb.append(PREFIX_FROM).append(freeTime.getFrom()).append(" ")
-                .append(PREFIX_TO).append(freeTime.getTo()).append(" "));
+        descriptor.getFreeTime().ifPresent(freeTime -> sb.append(PREFIX_FREE_TIME).append(freeTime));
 
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();


### PR DESCRIPTION
Currently FreeTime assumes that availability is same throughout the entire week.

However, in a realistic scenario, TAs have different availability throughout the week.

FreeTime is now modified to handle 5 TimeIntervals instead of 1.

We assume that TAs are only available from Monday to Friday

Closes #43 