### PR TITLE
Fix invalid range in isInBetween function

### DIFF
--- a/src/main/java/seedu/address/model/availability/TimeInterval.java
+++ b/src/main/java/seedu/address/model/availability/TimeInterval.java
@@ -44,8 +44,8 @@ public class TimeInterval {
      * @return True if this time interval is in between the given time interval.
      */
     public boolean isInBetween(TimeInterval intervalToCheckAgainst) {
-        return (this.from.isAfter(intervalToCheckAgainst.from) || this.from.equals(intervalToCheckAgainst.from))
-                && (this.to.isBefore(intervalToCheckAgainst.to) || this.to.equals(intervalToCheckAgainst.to));
+        return (this.from.isBefore(intervalToCheckAgainst.from) || this.from.equals(intervalToCheckAgainst.from))
+                && (this.to.isAfter(intervalToCheckAgainst.to) || this.to.equals(intervalToCheckAgainst.to));
     }
 
     /**


### PR DESCRIPTION
Invalid interval range is being used in current
implementation when comparing two intervals.

Fixing this would allow us to find TAs by
FreeTime more accurately.

For a current TimeInterval A, that is checking
against a TimeInterval B, we are checking,
* from of A is before or equal to from of B
* to of A is after or equal to to of B