### PR TITLE
Add command to clear default course

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearTeachCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearTeachCommand.java
@@ -5,6 +5,9 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.model.Model;
 import seedu.address.model.course.Course;
 
+/**
+ * Clears the default course.
+ */
 public class ClearTeachCommand extends Command {
 
     public static final String COMMAND_WORD = "clearteach";

--- a/src/main/java/seedu/address/logic/commands/ClearTeachCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearTeachCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+import seedu.address.model.course.Course;
+
+public class ClearTeachCommand extends Command {
+
+    public static final String COMMAND_WORD = "clearteach";
+    public static final String MESSAGE_SUCCESS = "Default course has been cleared!";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clears the default course.\n"
+            + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setTeaching(Course.EMPTY_COURSE);
+        return new CommandResult(MESSAGE_SUCCESS, false, false, true);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearTeachCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CourseCommand;
 import seedu.address.logic.commands.DeleteCommand;
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case TeachCommand.COMMAND_WORD:
             return new TeachCommandParser().parse(arguments);
+
+        case ClearTeachCommand.COMMAND_WORD:
+            return new ClearTeachCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/course/Course.java
+++ b/src/main/java/seedu/address/model/course/Course.java
@@ -21,6 +21,7 @@ public class Course {
     private final String name;
     private final String courseCode;
     private final Set<Lesson> lessons = new HashSet<>();
+    public static final Course EMPTY_COURSE = new Course();
 
 
     /**
@@ -36,6 +37,11 @@ public class Course {
         this.name = name;
         this.courseCode = courseCode;
         this.lessons.addAll(lessons);
+    }
+
+    private Course() {
+        this.name = "";
+        this.courseCode = "";
     }
 
     public String getName() {

--- a/src/main/java/seedu/address/model/course/Course.java
+++ b/src/main/java/seedu/address/model/course/Course.java
@@ -18,11 +18,11 @@ public class Course {
 
     // 2-3 alphabets, followed by 4 digits, and optionally ending with an alphabet
     public static final String VALIDATION_REGEX = "^[A-Za-z]{2,3}\\d{4}[A-Za-z]?$";
+    public static final Course EMPTY_COURSE = new Course();
+
     private final String name;
     private final String courseCode;
     private final Set<Lesson> lessons = new HashSet<>();
-    public static final Course EMPTY_COURSE = new Course();
-
 
     /**
      * Constructs a {@code Course}.

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -13,6 +13,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.ClearTeachCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -27,13 +28,13 @@ public class MainWindow extends UiPart<Stage> {
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
-    private Stage primaryStage;
-    private Logic logic;
+    private final Stage primaryStage;
+    private final Logic logic;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
-    private HelpWindow helpWindow;
+    private final HelpWindow helpWindow;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -81,6 +82,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -191,7 +193,12 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isTeach()) {
                 String course = commandResult.getFeedbackToUser().split(" ")[0];
-                this.getRoot().setTitle("TAManager (" + course + ")");
+                String resetString = ClearTeachCommand.MESSAGE_SUCCESS.split(" ")[0];
+                if (course.equals(resetString)) {
+                    this.getRoot().setTitle("TAManager");
+                } else {
+                    this.getRoot().setTitle("TAManager (" + course + ")");
+                }
             }
 
             return commandResult;

--- a/src/test/java/seedu/address/logic/commands/ClearTeachCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearTeachCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.course.Course;
+import seedu.address.model.course.CourseData;
+
+public class ClearTeachCommandTest {
+
+    @Test
+    public void execute_emptyUserPref_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+        CommandResult expectedCommandResult = new CommandResult(ClearTeachCommand.MESSAGE_SUCCESS,
+                false, false, true);
+
+        assertCommandSuccess(new ClearTeachCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyUserPref_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Course course = CourseData.getCourseList().get(0);
+        model.setTeaching(course);
+
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        CommandResult expectedCommandResult = new CommandResult(ClearTeachCommand.MESSAGE_SUCCESS,
+                false, false, true);
+
+        assertCommandSuccess(new ClearTeachCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+}


### PR DESCRIPTION
Currently there is not way to reset the default course except changing it in the preferences.json file.

This commit will add a new clearteach command that will reset the default course so that by default the user will view all course at the start.

Closes #66 