### PR TITLE
Fix where invalid dayOfWeek does not raise errors

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
@@ -13,6 +13,7 @@ import seedu.address.model.course.Lesson;
  */
 public class JsonAdaptedLesson {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Lesson's %s field is missing!";
+    public static final String CANNOT_BE_WEEKEND = "Day of week cannot be Saturday or Sunday";
     private final String name;
     private final String courseCode;
     private final String dayOfWeek;
@@ -51,6 +52,7 @@ public class JsonAdaptedLesson {
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "name"));
         }
+
         if (courseCode == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "courseCode"));
         }
@@ -59,9 +61,19 @@ public class JsonAdaptedLesson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "timeInterval"));
         }
 
+        if (dayOfWeek == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "dayOfWeek"));
+        }
+
+        DayOfWeek dayOfWeekModel = DayOfWeek.valueOf(dayOfWeek);
+
+        if (dayOfWeekModel == DayOfWeek.SATURDAY || dayOfWeekModel == DayOfWeek.SUNDAY) {
+            throw new IllegalValueException(CANNOT_BE_WEEKEND);
+        }
+
         return new Lesson(name,
                 courseCode,
-                DayOfWeek.valueOf(dayOfWeek),
+                dayOfWeekModel,
                 timeInterval.toModelType());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
@@ -1,0 +1,76 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.storage.JsonAdaptedLesson.CANNOT_BE_WEEKEND;
+import static seedu.address.storage.JsonAdaptedLesson.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.availability.FreeTime;
+import seedu.address.model.course.Lesson;
+import seedu.address.model.course.UniqueCourseList;
+
+public class JsonAdaptedLessonTest {
+
+    @Test
+    public void toModelType_validLessonDetails_returnsLesson() throws Exception {
+        Lesson modelLesson = UniqueCourseList.findLesson("CS2103T", "Lecture");
+        JsonAdaptedLesson lesson = new JsonAdaptedLesson(modelLesson);
+        assertEquals(lesson.toModelType(), modelLesson);
+    }
+
+    @Test
+    public void toModelType_missingName_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson(null, "Lecture", "Monday", new JsonAdaptedTimeInterval("12:00-13:00"));
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "name");
+        assertThrows(IllegalValueException.class, expectedMessage, lesson::toModelType);
+    }
+
+    @Test
+    public void toModelType_missingCourseCode_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson("CS2103T", null, "Monday", new JsonAdaptedTimeInterval("12:00-13:00"));
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "courseCode");
+        assertThrows(IllegalValueException.class, expectedMessage, lesson::toModelType);
+    }
+
+    @Test
+    public void toModelType_missingTimeInterval_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson("CS2103T", "Lecture", "Monday", null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "timeInterval");
+        assertThrows(IllegalValueException.class, expectedMessage, lesson::toModelType);
+    }
+
+    @Test
+    public void toModelType_missingDayOfWeek_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson("CS2103T", "Lecture", null, new JsonAdaptedTimeInterval("12:00-13:00"));
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "dayOfWeek");
+        assertThrows(IllegalValueException.class, expectedMessage, lesson::toModelType);
+    }
+
+    @Test
+    public void toModelType_weekendDayOfWeek_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson("CS2103T", "Lecture", "SATURDAY", new JsonAdaptedTimeInterval("12:00-13:00"));
+        assertThrows(IllegalValueException.class, CANNOT_BE_WEEKEND, lesson::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidTimeInterval_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson("CS2103T", "Lecture", "MONDAY", new JsonAdaptedTimeInterval("13:00-12:00"));
+        assertThrows(IllegalValueException.class, FreeTime.MESSAGE_CONSTRAINTS, lesson::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDayOfWeek_throwsIllegalValueException() {
+        JsonAdaptedLesson lesson =
+                new JsonAdaptedLesson("CS2103T", "Lecture", "MONDAYY", new JsonAdaptedTimeInterval("12:00-13:00"));
+        assertThrows(IllegalArgumentException.class, lesson::toModelType);
+    }
+}


### PR DESCRIPTION
Currently if the dayOfWeek in json file is changed to SATURDAY, the app will run as usual.

Since SATURDAY is an invalid value, the expected behaviour is that the addressbook will be empty.

Closes #116 